### PR TITLE
Initial running version on Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,6 +91,6 @@ jobs:
               if: matrix.settings.host == 'windows-latest'
               uses: actions/upload-artifact@v3
               with:
-                  name: Commit.exe
+                  name: Commit.msi
                   path: |
                       target/release/bundle/msi/Commit*.msi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
                   path: |
                       target/release/bundle/dmg/Commit*.dmg
 
-            - name: 🚀 Upload macOS App
+            - name: 🚀 Upload macOS app
               if: matrix.settings.host == 'macos-latest'
               uses: actions/upload-artifact@v3
               with:
@@ -79,10 +79,18 @@ jobs:
                   path: |
                       target/release/bundle/macos/
 
-            - name: 🚀 Upload Windows App
+            - name: 🚀 Upload Windows NSIS
               if: matrix.settings.host == 'windows-latest'
               uses: actions/upload-artifact@v3
               with:
                   name: Commit.exe
                   path: |
-                      target/release/bundle/windows/Commit.exe
+                      target/release/bundle/nsis/Commit*.exe
+
+            - name: 🚀 Upload Windows MSI
+              if: matrix.settings.host == 'windows-latest'
+              uses: actions/upload-artifact@v3
+              with:
+                  name: Commit.exe
+                  path: |
+                      target/release/bundle/msi/Commit*.msi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,18 @@ on:
 
 jobs:
     build:
-        runs-on: macos-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                settings:
+                    - host: macos-latest
+                      name: macOS
+                      targets: app,dmg
+                    - host: windows-latest
+                      name: Windows
+                      targets: msi,nsis
+        name: Build for ${{ matrix.settings.name }}
+        runs-on: ${{ matrix.settings.host }}
         steps:
             - name: Checkout the code
               uses: actions/checkout@v3
@@ -49,8 +60,11 @@ jobs:
 
             - name: Build the app
               uses: tauri-apps/tauri-action@v0
+              with:
+                  args: --bundles ${{ matrix.settings.targets }}
 
             - name: 🚀 Upload macOS dmg
+              if: matrix.settings.host == 'macos-latest'
               uses: actions/upload-artifact@v3
               with:
                   name: Commit.dmg
@@ -58,8 +72,17 @@ jobs:
                       target/release/bundle/dmg/Commit*.dmg
 
             - name: 🚀 Upload macOS App
+              if: matrix.settings.host == 'macos-latest'
               uses: actions/upload-artifact@v3
               with:
                   name: Commit.app
                   path: |
                       target/release/bundle/macos/
+
+            - name: 🚀 Upload Windows App
+              if: matrix.settings.host == 'windows-latest'
+              uses: actions/upload-artifact@v3
+              with:
+                  name: Commit.exe
+                  path: |
+                      target/release/bundle/windows/Commit.exe

--- a/frontend/src/components/ShortcutPicker.tsx
+++ b/frontend/src/components/ShortcutPicker.tsx
@@ -28,10 +28,6 @@ const ShortcutPicker: FC<Props> = ({ value, onChange }) => {
 		setShortcut(parseShortcut(value))
 	}, [value])
 
-	// useEffect(() => {
-	// 	onChange(buildShortcut(shortcut))
-	// }, [shortcut])
-
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLDivElement>) => {
 			event.preventDefault()
@@ -75,10 +71,10 @@ const parseShortcut = (shortcut: string): ParsedShortcut => {
 
 	return {
 		isAlt: parts.includes('Alt'),
-		isCmd: parts.includes('Cmd'),
 		isCtrl: parts.includes('Ctrl'),
 		isShift: parts.includes('Shift'),
 		natural: parts[parts.length - 1].toUpperCase(),
+		isCmd: parts.includes('CommandOrControl') || parts.includes('Cmd'),
 	}
 }
 
@@ -100,10 +96,10 @@ const displayShortcut = (shortcut: ParsedShortcut): string => {
 const buildShortcut = (shortcut: ParsedShortcut): string => {
 	let parts = []
 
-	if (shortcut.isCmd) parts.push('Cmd')
 	if (shortcut.isAlt) parts.push('Alt')
 	if (shortcut.isCtrl) parts.push('Ctrl')
 	if (shortcut.isShift) parts.push('Shift')
+	if (shortcut.isCmd) parts.push('CommandOrControl')
 
 	parts.push(shortcut.natural.toUpperCase())
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,11 @@
 use anyhow::anyhow;
 use config::{Config, ConfigExt};
 use std::error::Error;
-use tauri::{generate_context, ActivationPolicy, Builder as Tauri};
+use tauri::{generate_context, Builder as Tauri};
+
+#[cfg(target_os = "macos")]
+use tauri::ActivationPolicy;
+
 use tauri_autostart::ManagerExt;
 use tauri_plugin_autostart::{self as tauri_autostart};
 
@@ -33,6 +37,7 @@ fn main() {
 }
 
 fn setup_tauri(app: &mut tauri::App) -> Result<(), Box<(dyn Error + 'static)>> {
+	#[cfg(target_os = "macos")]
 	app.set_activation_policy(ActivationPolicy::Accessory);
 
 	window::main_window::create(&app.handle())?;

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -2,16 +2,8 @@ use tauri::{AppHandle, GlobalShortcutManager, Manager, Window};
 
 use crate::window;
 
-// todo: maybe use `cfg-if` crate for many platform-specific stuff
-#[cfg(target_os = "macos")]
-pub const DEFAULT_SHORTCUT: &str = "Cmd+Alt+Shift+C";
-#[cfg(target_os = "macos")]
-pub const SETTINGS_SHORTCUT: &str = "Cmd+,";
-
-#[cfg(target_os = "windows")]
-pub const DEFAULT_SHORTCUT: &str = "Ctrl+Alt+Shift+C";
-#[cfg(target_os = "windows")]
-pub const SETTINGS_SHORTCUT: &str = "Ctrl+Shift+,";
+pub const DEFAULT_SHORTCUT: &str = "CommandOrControl+Alt+Shift+C";
+pub const SETTINGS_SHORTCUT: &str = "CommandOrControl+,";
 
 pub fn update_default(
 	app: &AppHandle,

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -2,7 +2,16 @@ use tauri::{AppHandle, GlobalShortcutManager, Manager, Window};
 
 use crate::window;
 
+// todo: maybe use `cfg-if` crate for many platform-specific stuff
+#[cfg(target_os = "macos")]
 pub const DEFAULT_SHORTCUT: &str = "Cmd+Alt+Shift+C";
+#[cfg(target_os = "macos")]
+pub const SETTINGS_SHORTCUT: &str = "Cmd+,";
+
+#[cfg(target_os = "windows")]
+pub const DEFAULT_SHORTCUT: &str = "Ctrl+Alt+Shift+C";
+#[cfg(target_os = "windows")]
+pub const SETTINGS_SHORTCUT: &str = "Ctrl+Shift+,";
 
 pub fn update_default(
 	app: &AppHandle,
@@ -28,7 +37,7 @@ pub fn register_settings(app: &AppHandle) -> Result<(), anyhow::Error> {
 	let mut shortcuts = app.global_shortcut_manager();
 
 	let settings_window = window::settings::get(app).unwrap();
-	shortcuts.register("Cmd+,", move || {
+	shortcuts.register(SETTINGS_SHORTCUT, move || {
 		settings_window.show().unwrap();
 		settings_window.set_focus().unwrap();
 	})?;
@@ -39,7 +48,7 @@ pub fn register_settings(app: &AppHandle) -> Result<(), anyhow::Error> {
 pub fn unregister_settings(app: &AppHandle) -> Result<(), anyhow::Error> {
 	let mut shortcuts = app.global_shortcut_manager();
 
-	shortcuts.unregister("Cmd+,")?;
+	shortcuts.unregister(SETTINGS_SHORTCUT)?;
 
 	Ok(())
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -15,13 +15,13 @@ pub enum TrayMenu {
 
 pub fn build() -> SystemTray {
 	let tray_menu = SystemTrayMenu::new()
-		.add_item(CustomMenuItem::new(TrayMenu::Settings, "Settings...").accelerator("Cmd+,"))
+		.add_item(CustomMenuItem::new(TrayMenu::Settings, "Settings...").accelerator("CommandOrControl+,"))
 		.add_native_item(SystemTrayMenuItem::Separator);
 
 	#[cfg(debug_assertions)]
 	let tray_menu = tray_menu
 		.add_item(
-			CustomMenuItem::new(TrayMenu::DevTools, "Open DevTools").accelerator("Cmd+Shift+I"),
+			CustomMenuItem::new(TrayMenu::DevTools, "Open DevTools").accelerator("CommandOrControl+Shift+I"),
 		)
 		.add_native_item(SystemTrayMenuItem::Separator);
 

--- a/src/window/main_window.rs
+++ b/src/window/main_window.rs
@@ -37,7 +37,9 @@ pub fn hide(window: &Window) -> Result<(), tauri_plugin_spotlight::Error> {
 
 pub fn on_open(window: Window) {
 	shortcuts::register_escape(window.clone()).unwrap();
-	shortcuts::register_settings(&window.app_handle()).unwrap();
+	shortcuts::register_settings(&window.app_handle()).unwrap_or_else(|_| {
+		eprintln!("Failed to register settings shortcut");
+	});
 
 	tauri::async_runtime::spawn(async move {
 		let app = window.app_handle();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -7,7 +7,7 @@ use tauri_plugin_spotlight::{PluginConfig, WindowConfig};
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
 
 #[cfg(target_os = "windows")]
-use window_vibrancy::apply_blur;
+use window_vibrancy::apply_mica;
 
 use crate::shortcuts;
 
@@ -83,6 +83,6 @@ impl TransparentWindow for Window {
 		
 		// not working
 		#[cfg(target_os = "windows")]
-		apply_blur(self, Some((18, 18, 18, 125)))
+		apply_mica(self, Some(false))
 	}
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -2,7 +2,12 @@ use tauri::{
 	plugin::TauriPlugin, AppHandle, GlobalWindowEvent, Manager, RunEvent, Window, WindowEvent,
 };
 use tauri_plugin_spotlight::{PluginConfig, WindowConfig};
+
+#[cfg(target_os = "macos")]
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
+
+#[cfg(target_os = "windows")]
+use window_vibrancy::apply_mica;
 
 use crate::shortcuts;
 
@@ -66,11 +71,17 @@ pub trait TransparentWindow {
 
 impl TransparentWindow for Window {
 	fn make_transparent(&self) -> Result<(), window_vibrancy::Error> {
-		apply_vibrancy(
-			self,
-			NSVisualEffectMaterial::HudWindow,
-			Some(NSVisualEffectState::Active),
-			Some(10.0),
-		)
+		{
+			#[cfg(target_os = "macos")]
+			apply_vibrancy(
+				self,
+				NSVisualEffectMaterial::HudWindow,
+				Some(NSVisualEffectState::Active),
+				Some(10.0),
+			)
+		}
+		
+		#[cfg(target_os = "windows")]
+		apply_mica(self, Some(false))
 	}
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -7,7 +7,7 @@ use tauri_plugin_spotlight::{PluginConfig, WindowConfig};
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
 
 #[cfg(target_os = "windows")]
-use window_vibrancy::apply_mica;
+use window_vibrancy::apply_blur;
 
 use crate::shortcuts;
 
@@ -81,7 +81,8 @@ impl TransparentWindow for Window {
 			)
 		}
 		
+		// not working
 		#[cfg(target_os = "windows")]
-		apply_mica(self, Some(false))
+		apply_blur(self, Some((18, 18, 18, 125)))
 	}
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,11 +1,14 @@
 use anyhow::anyhow;
-use tauri::{AppHandle, Manager, TitleBarStyle, Window, WindowBuilder, WindowUrl};
+use tauri::{AppHandle, Manager, Window, WindowBuilder, WindowUrl};
+#[cfg(target_os = "macos")]
+use tauri::TitleBarStyle;
 
 use crate::window;
 
 use super::TransparentWindow;
 
 pub fn create(app: &AppHandle) -> anyhow::Result<Window> {
+	#[cfg(target_os = "macos")]
 	let settings_window =
 		WindowBuilder::new(app, window::SETTINGS, WindowUrl::App(Default::default()))
 			.visible(false)
@@ -14,6 +17,18 @@ pub fn create(app: &AppHandle) -> anyhow::Result<Window> {
 			.always_on_top(true)
 			.title("Settings - Commit")
 			.title_bar_style(TitleBarStyle::Overlay)
+			.initialization_script("window.__COMMIT__ = { page: 'settings' };")
+			.build()?;
+
+	// not macos
+	#[cfg(not(target_os = "macos"))]
+	let settings_window =
+		WindowBuilder::new(app, window::SETTINGS, WindowUrl::App(Default::default()))
+			.visible(false)
+			.closable(true)
+			.transparent(true)
+			.always_on_top(true)
+			.title("Settings - Commit")
 			.initialization_script("window.__COMMIT__ = { page: 'settings' };")
 			.build()?;
 


### PR DESCRIPTION
Related: #5 

Added compiler macros to isolate platform-specific code, allowing it to compile on Windows.

Working:
- Basic function
- Open commit window shortcut

Not working:
- Window vibrancy (had no luck with mica/acrylic/blur - they just don't work)
- Tiny black space on rounded corner
- Open settings shortcut (no idea, maybe some broken cache on my system)

---
![image](https://github.com/m1guelpf/commit/assets/33322229/224c42a8-4b8e-4145-ac12-5a364230029d)
---
![image](https://github.com/m1guelpf/commit/assets/33322229/349c1048-5616-4865-85bf-3d105a650b0b)
---
![image](https://github.com/m1guelpf/commit/assets/33322229/157eb866-8bb7-4bcd-a612-cf97b360e3ab)
